### PR TITLE
fixed the bug that caused modified to show on /etc/grub/default when …

### DIFF
--- a/main.py
+++ b/main.py
@@ -832,7 +832,7 @@ class Ui(QtWidgets.QMainWindow):
         """returns the value comboBox grub_default should have"""
         grub_default_val =get_value('GRUB_DEFAULT=',self.issues)
             
-        grub_default_val=grub_default_val.replace('>',' >')
+       
         return grub_default_val
                 
     def setUiElements(self,reload_confs=True,show_issues=True,only_snapshots=False):

--- a/todo.txt
+++ b/todo.txt
@@ -17,3 +17,5 @@ fix bug that causes the loading configuration from to change when default text e
 pop the last invalid default entry when fix has finished
 
 checkbox do this everytime in invalid grub default fixer
+
+remove the use of get_comboBox_grub_default function


### PR DESCRIPTION
…switching configuration back (it only happened when it had a default entry)